### PR TITLE
No video in tutorial bugfix issue 8

### DIFF
--- a/app/facades/tutorial_facade.rb
+++ b/app/facades/tutorial_facade.rb
@@ -5,7 +5,7 @@ class TutorialFacade < SimpleDelegator
   end
 
   def videos?
-    if videos.count > 0
+    if videos.count.positive?
       true
     else
       false

--- a/app/facades/tutorial_facade.rb
+++ b/app/facades/tutorial_facade.rb
@@ -4,6 +4,14 @@ class TutorialFacade < SimpleDelegator
     @video_id = video_id
   end
 
+  def videos?
+    if videos.count > 0
+      true
+    else
+      false
+    end
+  end
+
   def current_video
     if @video_id
       videos.find(@video_id)

--- a/app/views/tutorials/show.html.erb
+++ b/app/views/tutorials/show.html.erb
@@ -13,6 +13,7 @@
 </div>
 
 <div class="col col-8">
+  <% if @facade.videos? %>
   <div class="title-bookmark">
     <h3><%= @facade.current_video.title %></h3>
     <div class="bookmarks-btn">
@@ -64,6 +65,10 @@
     <%= @facade.current_video.description.truncate(50) %>...
     <%= link_to "More", "#", "data-action" => "click->tutorials#showDescription", id: @facade.current_video.id, class: "show-link"%>
   </p>
+  <% else %>
+  <p>This tutorial has no videos yet!</p>
+  <%= link_to "Back to homepage", root_path %>
+  <% end %>
 </div>
 
 </main>

--- a/spec/features/user/user_visits_tutorial_page_spec.rb
+++ b/spec/features/user/user_visits_tutorial_page_spec.rb
@@ -1,0 +1,19 @@
+require 'rails_helper'
+
+describe 'As a user' do
+  describe 'When I visit a tutorial show page that has no videos' do
+    it 'shows a message stating that the tutorial is empty' do
+      user = create(:user)
+      tutorial = create(:tutorial)
+      allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(user)
+
+      visit tutorial_path(tutorial)
+
+      expect(page).to_not have_content("Description")
+      expect(page).to_not have_button("Bookmark")
+      expect(page).to_not have_link("Bookmark")
+      expect(page).to have_content("This tutorial has no videos yet!")
+      expect(page).to have_link('Back to homepage')
+    end
+  end
+end

--- a/spec/features/user/user_visits_tutorial_page_spec.rb
+++ b/spec/features/user/user_visits_tutorial_page_spec.rb
@@ -9,10 +9,10 @@ describe 'As a user' do
 
       visit tutorial_path(tutorial)
 
-      expect(page).to_not have_content("Description")
-      expect(page).to_not have_button("Bookmark")
-      expect(page).to_not have_link("Bookmark")
-      expect(page).to have_content("This tutorial has no videos yet!")
+      expect(page).to_not have_content('Description')
+      expect(page).to_not have_button('Bookmark')
+      expect(page).to_not have_link('Bookmark')
+      expect(page).to have_content('This tutorial has no videos yet!')
       expect(page).to have_link('Back to homepage')
     end
   end


### PR DESCRIPTION
Created a test to replicate the error.
If a tutorial contained no videos the show page would crash. 
Added a method, #videos?, to check if the tutorial contained videos and added an if block that would replace the video player with an alert and a link to the homepage.

Bug successfully patched

All tests currently pass
test coverage; 83.5%

closes #8 