### PR TITLE
Bugfix adjustment for tutorials missing videos crashing show page

### DIFF
--- a/app/facades/tutorial_facade.rb
+++ b/app/facades/tutorial_facade.rb
@@ -5,7 +5,7 @@ class TutorialFacade < SimpleDelegator
   end
 
   def current_video
-    if videos.count == 0
+    if videos.count.zero?
       videos << Video.new(title: 'No Videos', description: 'Check back soon!')
       videos.first
     elsif @video_id

--- a/app/facades/tutorial_facade.rb
+++ b/app/facades/tutorial_facade.rb
@@ -4,16 +4,11 @@ class TutorialFacade < SimpleDelegator
     @video_id = video_id
   end
 
-  def videos?
-    if videos.count.positive?
-      true
-    else
-      false
-    end
-  end
-
   def current_video
-    if @video_id
+    if videos.count == 0
+      videos << Video.new(title: 'No Videos', description: 'Check back soon!')
+      videos.first
+    elsif @video_id
       videos.find(@video_id)
     else
       videos.first

--- a/app/views/tutorials/show.html.erb
+++ b/app/views/tutorials/show.html.erb
@@ -13,7 +13,6 @@
 </div>
 
 <div class="col col-8">
-  <% if @facade.videos? %>
   <div class="title-bookmark">
     <h3><%= @facade.current_video.title %></h3>
     <div class="bookmarks-btn">
@@ -65,10 +64,6 @@
     <%= @facade.current_video.description.truncate(50) %>...
     <%= link_to "More", "#", "data-action" => "click->tutorials#showDescription", id: @facade.current_video.id, class: "show-link"%>
   </p>
-  <% else %>
-  <p>This tutorial has no videos yet!</p>
-  <%= link_to "Back to homepage", root_path %>
-  <% end %>
 </div>
 
 </main>

--- a/spec/features/user/user_visits_tutorial_page_spec.rb
+++ b/spec/features/user/user_visits_tutorial_page_spec.rb
@@ -9,11 +9,8 @@ describe 'As a user' do
 
       visit tutorial_path(tutorial)
 
-      expect(page).to_not have_content('Description')
-      expect(page).to_not have_button('Bookmark')
-      expect(page).to_not have_link('Bookmark')
-      expect(page).to have_content('This tutorial has no videos yet!')
-      expect(page).to have_link('Back to homepage')
+      expect(page).to have_content('No Videos')
+      expect(page).to have_content('Check back soon!')
     end
   end
 end


### PR DESCRIPTION
Removes if logic from the tutorial show page

creates dummy object to act as a filler so the video can load but will alert the user that there are no videos present

adjusts test to expect the new data.

bug fixed much more cleanly now.

All tests passing, test coverage: 83.45%